### PR TITLE
支持用户使用自己的 ObjectMapper

### DIFF
--- a/src/main/java/com/github/weaksloth/dolphins/process/ProcessOperator.java
+++ b/src/main/java/com/github/weaksloth/dolphins/process/ProcessOperator.java
@@ -2,6 +2,7 @@ package com.github.weaksloth.dolphins.process;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.weaksloth.dolphins.common.PageInfo;
 import com.github.weaksloth.dolphins.core.AbstractOperator;
 import com.github.weaksloth.dolphins.core.DolphinClientConstant;
@@ -9,6 +10,7 @@ import com.github.weaksloth.dolphins.core.DolphinException;
 import com.github.weaksloth.dolphins.remote.DolphinsRestTemplate;
 import com.github.weaksloth.dolphins.remote.HttpRestResult;
 import com.github.weaksloth.dolphins.remote.Query;
+import com.github.weaksloth.dolphins.task.*;
 import com.github.weaksloth.dolphins.util.JacksonUtils;
 import java.util.List;
 import java.util.Optional;
@@ -175,6 +177,67 @@ public class ProcessOperator extends AbstractOperator {
     return release(projectCode, code, ProcessReleaseParam.newOfflineInstance());
   }
 
+  /**
+   * query task definition by task code
+   *
+   * @param projectCode project code
+   * @param taskCode task definition code
+   * @return task definition
+   */
+  public TaskDefinition queryTaskDefinition(Long projectCode, Long taskCode) {
+    String url = dolphinAddress + "/projects/" + projectCode + "/task-definition/" + taskCode;
+    try {
+      HttpRestResult<JsonNode> restResult =
+          this.dolphinsRestTemplate.get(url, this.getHeader(), null, JsonNode.class);
+      if (restResult.getSuccess()) {
+        JsonNode data = restResult.getData();
+        String taskType = data.get("taskType").asText();
+        JsonNode taskParamsNode = data.get("taskParams");
+
+        AbstractTask taskParams = null;
+        if (taskParamsNode != null) {
+          Class<? extends AbstractTask> taskClass = matchTaskClass(taskType);
+          taskParams = JacksonUtils.parseObject(taskParamsNode.toString(), taskClass);
+        }
+        if (data.isObject()) {
+          ((ObjectNode) data).remove("taskParams");
+        }
+        TaskDefinition taskDefinition =
+            JacksonUtils.parseObject(data.toString(), TaskDefinition.class);
+        if (taskParams != null) {
+          taskDefinition.setTaskParams(taskParams);
+        }
+        return taskDefinition;
+      }
+      log.error("query task definition response:{}", restResult);
+      throw new DolphinException("query dolphin scheduler task definition fail");
+    } catch (Exception e) {
+      throw new DolphinException("query dolphin scheduler task definition fail", e);
+    }
+  }
+
+  private static Class<? extends AbstractTask> matchTaskClass(String taskType) {
+    switch (taskType) {
+      case "SHELL":
+        return ShellTask.class;
+      case "SQL":
+        return SqlTask.class;
+      case "PROCEDURE":
+        return ProcedureTask.class;
+      case "HTTP":
+        return HttpTask.class;
+      case "PYTHON":
+        return PythonTask.class;
+      case "DATAX":
+        return DataxTask.class;
+      case "CONDITIONS":
+        return ConditionTask.class;
+      case "SPARK":
+        return SparkTask.class;
+      default:
+        return GenericTask.class;
+    }
+  }
   /**
    * generate task code
    *

--- a/src/main/java/com/github/weaksloth/dolphins/task/GenericTask.java
+++ b/src/main/java/com/github/weaksloth/dolphins/task/GenericTask.java
@@ -1,0 +1,28 @@
+package com.github.weaksloth.dolphins.task;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+/**
+ * Generic task for handling unknown or custom task types. Captures the raw task parameters as a
+ * JsonNode.
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Accessors(chain = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenericTask extends AbstractTask {
+
+  private String taskType;
+  private JsonNode taskParams;
+
+  @Override
+  public String getTaskType() {
+    return this.taskType;
+  }
+}

--- a/src/main/java/com/github/weaksloth/dolphins/util/JacksonUtils.java
+++ b/src/main/java/com/github/weaksloth/dolphins/util/JacksonUtils.java
@@ -13,7 +13,7 @@ import java.lang.reflect.Type;
 /** json utils based on jackson */
 public class JacksonUtils {
 
-  private static final ObjectMapper mapper = new ObjectMapper();
+  private static ObjectMapper mapper = new ObjectMapper();
 
   public static ObjectNode createObjectNode() {
     return mapper.createObjectNode();
@@ -21,6 +21,10 @@ public class JacksonUtils {
 
   public static ArrayNode createArrayNode() {
     return mapper.createArrayNode();
+  }
+
+  public static void setObjectMapper(ObjectMapper objectMapper) {
+    mapper = objectMapper;
   }
 
   /**


### PR DESCRIPTION
我们正在使用 3.2.0-release 分支访问 Apache DolphinScheduler 3.2.2，由于 project / process 等相关接口新增了一些属性（例如 `project.type`），现有的代码会在解析时抛出 Jackson 异常。

一种出于简单兼容的解决方案是通过  `ObjectMapper#disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)` 忽略未定义的属性。

考虑到许多开发者对 ObjectMapper 有自己的配置，是否可以允许替换 `com.github.weaksloth.dolphins.util.JacksonUtils` 的 `mapper` 成员。